### PR TITLE
Fix config tokens and runtime file

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,2 +1,7 @@
-TELEGRAM_TOKEN = '7851905982:AAFE4yEGXZyW1WerAiyMaQPoJ6Pa7CZaRQc'
-OPENROUTER_API_KEY = 'sk-or-v1-e8944abefd37637da7e79aa32103626801df6fbf4d30b81fdd6db636deb3679'
+import os
+
+TELEGRAM_TOKEN = os.environ.get('TELEGRAM_TOKEN')
+OPENROUTER_API_KEY = os.environ.get('OPENROUTER_API_KEY')
+
+if not TELEGRAM_TOKEN or not OPENROUTER_API_KEY:
+    raise EnvironmentError('Required environment variables TELEGRAM_TOKEN and OPENROUTER_API_KEY are not set')

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-runtime.txt
+python-3.10.11


### PR DESCRIPTION
## Summary
- read Telegram and OpenRouter tokens from environment variables
- correct Heroku `runtime.txt`

## Testing
- `python -m py_compile deep.py dummyfile.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_6849f0714134832989a60be3ac5b5a7b